### PR TITLE
reintroduce fsync for non-linux OSes

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package voidDB
+
+func (void *Void) fsync() error {
+	return void.file.Sync()
+}

--- a/fsync_linux.go
+++ b/fsync_linux.go
@@ -1,0 +1,11 @@
+package voidDB
+
+import (
+	"syscall"
+)
+
+func (void *Void) fsync() error {
+	return syscall.Fdatasync(
+		int(void.file.Fd()),
+	)
+}

--- a/void.go
+++ b/void.go
@@ -260,12 +260,6 @@ func (void *Void) write(data []byte, offset int) (e error) {
 	return
 }
 
-func (void *Void) fsync() error {
-	return syscall.Fdatasync(
-		int(void.file.Fd()),
-	)
-}
-
 func logarithm(size int) (exp int) {
 	for exp = 3; 1<<exp < size; exp++ {
 		continue


### PR DESCRIPTION
commit 803f3d812bc9b7398af1d5a0b4d938685da6c781 replaces `File.Sync` with a call to `Fdatasync`, which only exists on Linux. The closet equivalent on MacOS is `F_FULLFSYNC`, which `File.Sync` uses under the hood since [go 1.12](https://go.dev/doc/go1.12). This restores the old behavior for non-linux operating systems. It's not known whether the implementations for other GOOS targets will provide similar guarantees, but for MacOS at least, this should be the way to go.